### PR TITLE
Fix week numbering bug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,2 @@
+test:
+	go test -v .

--- a/src/date.go
+++ b/src/date.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jinzhu/now"
+)
+
+type date struct {
+	Year          string
+	WeekStartDate string
+	WeekEndDate   string
+	WeekNumber    string
+	Dates         [7]string
+}
+
+func NewDate(t time.Time) *date {
+	d := &date{}
+
+	nc := &now.Config{
+		WeekStartDay: time.Monday,
+	}
+	n := nc.With(t)
+
+	d.Year = n.BeginningOfYear().Format("2006")
+	d.WeekEndDate = n.EndOfSunday().Format("01/02")
+	d.WeekStartDate = n.BeginningOfWeek().Format("01/02")
+	_, isoweek := n.Monday().ISOWeek()
+	d.WeekNumber = fmt.Sprintf("%02d", isoweek)
+	for j := range d.Dates {
+		d.Dates[j] = n.Monday().AddDate(0, 0, j).Format("01/02")
+	}
+	return d
+}

--- a/src/date.go
+++ b/src/date.go
@@ -8,11 +8,12 @@ import (
 )
 
 type date struct {
-	Year          string
-	WeekStartDate string
-	WeekEndDate   string
-	WeekNumber    string
-	Dates         [7]string
+	Year           string
+	WeekStartDate  string
+	WeekEndDate    string
+	WeekNumber     string
+	WeekNumberYear string
+	Dates          [7]string
 }
 
 func NewDate(t time.Time) *date {
@@ -31,5 +32,10 @@ func NewDate(t time.Time) *date {
 	for j := range d.Dates {
 		d.Dates[j] = n.Monday().AddDate(0, 0, j).Format("01/02")
 	}
+	// Thursday of the week, should be used with the week number
+	// e.g. "2020 Week 01".
+	// See https://en.wikipedia.org/wiki/ISO_week_date#First_week
+	// for the ISO 8601 first week definition
+	d.WeekNumberYear = n.BeginningOfWeek().AddDate(0, 0, 3).Format("2006")
 	return d
 }

--- a/src/date_test.go
+++ b/src/date_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	now    string
+	should string
+}
+
+func TestNewDate(t *testing.T) {
+	testCases := []testCase{
+		// Monday when Jan 1st is Monday
+		{now: "2018-01-01T00:00:00Z", should: "2018 Week 01"},
+		// Monday when Jan 1st is Tuesday
+		{now: "2018-12-31T00:00:00Z", should: "2019 Week 01"},
+		// Monday when Jan 1st is Wednesday
+		{now: "2019-12-30T00:00:00Z", should: "2020 Week 01"},
+		// Monday when Jan 1st is Thursday
+		{now: "2025-12-29T00:00:00Z", should: "2026 Week 01"},
+		// Monday when Jan 1st is Friday
+		{now: "2020-12-28T00:00:00Z", should: "2020 Week 53"},
+		// Monday when Jan 1st is Saturday
+		{now: "2021-12-27T00:00:00Z", should: "2021 Week 52"},
+		// Monday when Jan 1st is Saturday and it's a leap year
+		{now: "2032-12-27T00:00:00Z", should: "2032 Week 53"},
+		// Monday when Jan 1st is Sunday
+		{now: "2022-12-26T00:00:00Z", should: "2022 Week 52"},
+	}
+
+	for _, v := range testCases {
+		t.Logf("Testing %v...", v.now)
+		now, err := time.Parse(time.RFC3339, v.now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		d := NewDate(now)
+		current := d.WeekNumberYear + " Week " + d.WeekNumber
+		if current != v.should {
+			t.Errorf("Actual: %v, Should: %v\n", current, v.should)
+		}
+	}
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,6 +3,6 @@ module github.com/lowply/issue-from-template
 go 1.12
 
 require (
-	github.com/jinzhu/now v1.0.0
+	github.com/jinzhu/now v1.1.1
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,5 +1,5 @@
-github.com/jinzhu/now v1.0.0 h1:6WV8LvwPpDhKjo5U9O6b4+xdG/jTXNPwlDme/MTo8Ns=
-github.com/jinzhu/now v1.0.0/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
+github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
The `.Year` variable just returns a year of the day when the action run, so it's not 100% accurate when used as [the year of the first week](https://en.wikipedia.org/wiki/ISO_week_date#First_week). This PR fixes it by adding the `.WeekNumberYear` variable.