### PR TITLE
Add ADD_DATES option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This action opens a new issue from an issue template. It parses the template's f
 ## Environment variables
 
 - `IFT_TEMPLATE_NAME` (*required*): The name of the issue template. For example, `report.md`. This action will look for the file in the `.github/ISSUE_TEMPLATE` directory.
+- `ADD_DATES` (*optional*): Number of the dates to add. This is useful when you want to run this action to open an issue for the next week, not this week.
 
 ## Available template variables
 

--- a/src/issue.go
+++ b/src/issue.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -24,7 +25,15 @@ type issue struct {
 func NewIssue() *issue {
 	i := &issue{}
 	i.request = NewRequest(201)
-	i.date = NewDate(time.Now())
+	if os.Getenv("ADD_DATES") == "" {
+		i.date = NewDate(time.Now())
+	} else {
+		dates, err := strconv.Atoi(os.Getenv("ADD_DATES"))
+		if err != nil {
+			return nil
+		}
+		i.date = NewDate(time.Now().AddDate(0, 0, dates))
+	}
 	i.endpoint = "https://api.github.com/repos/" + os.Getenv("GITHUB_REPOSITORY") + "/issues"
 	i.template = filepath.Join(os.Getenv("GITHUB_WORKSPACE"), ".github", "ISSUE_TEMPLATE", os.Getenv("IFT_TEMPLATE_NAME"))
 	return i


### PR DESCRIPTION
Adding a new option.

`ADD_DATES` (*optional*): Number of the dates to add. This is useful when you want to run this action to open an issue for the next week, not this week.